### PR TITLE
Update super-linter config

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run github/super-linter
-      uses: docker://github/super-linter:v3.15.3
+      uses: docker://github/super-linter:v4.0.2
       env:
         # Lint all code
         VALIDATE_ALL_CODEBASE: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ override.tf.json
 
 # Ignore Visual Studio Code config
 **/.vscode/*
+
+# Ignore Super-Linter log
+**/super-linter.report
+**/super-linter.report/*
+**/super-linter.log


### PR DESCRIPTION
This PR updates `github/super-linter` to the latest version, and adds the paths of log outputs to `.gitignore` to allow local running.